### PR TITLE
Make server-side safe (for SSR)

### DIFF
--- a/src/stored-observable.js
+++ b/src/stored-observable.js
@@ -18,6 +18,8 @@ const checkReservedKeys = obj => {
 }
 
 function factory(storage) {
+  if (typeof process !== 'undefined' || process.release.name === 'node') return
+
   return function storedObservable(
     key,
     defaultValue,

--- a/src/stored-observable.js
+++ b/src/stored-observable.js
@@ -18,8 +18,6 @@ const checkReservedKeys = obj => {
 }
 
 function factory(storage) {
-  if (typeof process !== 'undefined' || process.release.name === 'node') return
-
   return function storedObservable(
     key,
     defaultValue,
@@ -81,5 +79,15 @@ function factory(storage) {
   }
 }
 
-export const localStored = factory(localStorage)
-export const sessionStored = factory(sessionStorage)
+var localStored
+var sessionStored
+
+if (process && process.release && process.release.name === 'node') {
+  localStored = factory({})
+  sessionStored = factory({})
+} else {
+  localStored = factory(localStorage)
+  sessionStored = factory(sessionStorage)
+}
+
+export { localStored, sessionStored, factory }

--- a/src/stored-observable.spec.js
+++ b/src/stored-observable.spec.js
@@ -2,7 +2,9 @@
 import './sessionStorage-mock'
 import 'localstorage-polyfill'
 import test from 'ava'
-import { localStored } from './stored-observable'
+
+import { factory } from './stored-observable'
+const localStored = factory(global.localStorage)
 
 global.window = {
   addEventListener() {},


### PR DESCRIPTION
Hi there, 

This PR should make your library work even on Node. Why do I want this? I have a universal react app with the following use case: 

- Imagine a global auth singleton implemented in MobX.
- On the client side, it can query local storage for session information.
- On the server side, what happens? I provide the same payload for SSR using an `httpOnly` cookie.

This implementation was previously broken, because the package would attempt to immediately reference `localStorage` which is unavailable on Node. I _think_ that the assertion added should cover most use cases (but I'd be happy to find out if there's a better way to do this).

Thanks!